### PR TITLE
[FIX] Allows repository URL to separate project name with ':'

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -48,7 +48,7 @@ class Project < ActiveRecord::Base
   private
   
   def set_name
-    self.name = repo_url[/^.+\/(\w+)(?:\.git)?$/,1]
+    self.name = repo_url[/^.+[\/:](\w+)(?:\.git)?$/,1]
   end
   
   def repo_path


### PR DESCRIPTION
Hi,

Just checked out your project because I loved the idea when you showed it earlier at Cookpad.

However, straight up I ran into a minor issue :) When specifying a git repository URL in old gitosis format such as

`git@example.com:project.git`

the project name would not be correctly set in the `set_name` before_filter, so here's a small patch to allow the separator to be either `/` or `:`

Thanks,
Zaki
